### PR TITLE
Changed the printQuock() access to private.

### DIFF
--- a/text/96_private_methods_java.md
+++ b/text/96_private_methods_java.md
@@ -109,7 +109,7 @@ public class ReflectionFun {
         System.out.println("Quack!");
     }
 
-    public void printQuock() {
+    private void printQuock() {
         System.out.println("Quock!");
     }
 


### PR DESCRIPTION
In this chapter, printQuock() was incorrectly declared as a public method in the example code even though it was stated that printQuock() would be added as a private method.
